### PR TITLE
Add `NoDiscard` attribute on mutation free methods

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -14,4 +14,7 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <issueHandlers>
+        <UndefinedAttributeClass errorLevel="suppress" />
+    </issueHandlers>
 </psalm>

--- a/src/LineParser.php
+++ b/src/LineParser.php
@@ -13,5 +13,6 @@ interface LineParser
     /**
      * @return Maybe<Log>
      */
+    #[\NoDiscard]
     public function __invoke(Str $line): Maybe;
 }

--- a/src/Log.php
+++ b/src/Log.php
@@ -41,11 +41,13 @@ final class Log
         return new self($time, $raw, $attributes);
     }
 
+    #[\NoDiscard]
     public function time(): PointInTime
     {
         return $this->time;
     }
 
+    #[\NoDiscard]
     public function raw(): Str
     {
         return $this->raw;
@@ -54,6 +56,7 @@ final class Log
     /**
      * @return Set<Attribute>
      */
+    #[\NoDiscard]
     public function attributes(): Set
     {
         return $this->attributes;
@@ -62,16 +65,19 @@ final class Log
     /**
      * @return Maybe<Attribute>
      */
+    #[\NoDiscard]
     public function attribute(string $key): Maybe
     {
         return $this->attributes->find(static fn($attribute) => $attribute->key() === $key);
     }
 
+    #[\NoDiscard]
     public function equals(self $log): bool
     {
         return $this->raw->equals($log->raw());
     }
 
+    #[\NoDiscard]
     public function toString(): string
     {
         return $this->raw->toString();

--- a/src/Log/Attribute.php
+++ b/src/Log/Attribute.php
@@ -8,6 +8,8 @@ namespace Innmind\LogReader\Log;
  */
 interface Attribute
 {
+    #[\NoDiscard]
     public function key(): string;
+    #[\NoDiscard]
     public function value(): mixed;
 }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -18,6 +18,7 @@ final class Reader
         $this->parse = $parser;
     }
 
+    #[\NoDiscard]
     public function __invoke(Content $file): Sequence
     {
         /**


### PR DESCRIPTION
Since the attribute is not available on all supported versions Psalm complains. But this should be fine hence the error suppression in the config.